### PR TITLE
Specify blst include dir in Makefile 

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -5,28 +5,29 @@ LIB_SRC = bls12_381.c c_kzg_util.c das_extension.c fft_common.c fft_fr.c fft_g1.
 LIB_OBJ = $(LIB_SRC:.c=.o)
 
 CFLAGS =
+INCLUDE_DIRS = ../inc
 
 .PRECIOUS: %.o
 
 %.o: %.c %.h c_kzg.h Makefile
-	clang -Wall $(CFLAGS) -c $*.c
+	clang -Wall -I$(INCLUDE_DIRS) $(CFLAGS) -c $*.c
 
 libckzg.a: $(LIB_OBJ) Makefile
 	ar rc libckzg.a $(LIB_OBJ)
 
 %_test: %_test.c debug_util.o test_util.o libckzg.a Makefile
-	clang -Wall $(CFLAGS) -o $@ $@.c debug_util.o test_util.o libckzg.a -L../lib -lblst
+	clang -Wall -I$(INCLUDE_DIRS) $(CFLAGS) -o $@ $@.c debug_util.o test_util.o libckzg.a -L../lib -lblst
 	./$@
 
 # This version will abort on error and print the file and line number
 %_test_debug: CFLAGS += -g -O0 -DDEBUG
 %_test_debug: %_test.c debug_util.o test_util.o libckzg.a Makefile
-	clang -Wall $(CFLAGS) -o $@ $*_test.c debug_util.o test_util.o libckzg.a -L../lib -lblst
+	clang -Wall -I$(INCLUDE_DIRS) $(CFLAGS) -o $@ $*_test.c debug_util.o test_util.o libckzg.a -L../lib -lblst
 
 # Benchmarks
 %_bench: CFLAGS += -O
 %_bench: %_bench.c bench_util.o test_util.o $(LIB_OBJ) Makefile
-	clang -Wall $(CFLAGS) -o $@ $@.c bench_util.o test_util.o $(LIB_OBJ) -L../lib -lblst
+	clang -Wall -I$(INCLUDE_DIRS) $(CFLAGS) -o $@ $@.c bench_util.o test_util.o $(LIB_OBJ) -L../lib -lblst
 	./$@
 
 lib: CFLAGS += -O

--- a/src/bls12_381.h
+++ b/src/bls12_381.h
@@ -34,7 +34,7 @@
 // Settings for linking with the BLST library
 #ifdef BLST
 
-#include "../inc/blst.h"
+#include "blst.h"
 
 typedef blst_scalar scalar_t; /**< Internal scalar type */
 typedef blst_fr fr_t;         /**< Internal Fr field element type */


### PR DESCRIPTION
I removed the specific include path from `.h` and specified it in the `Makefile`
This is to avoid copying blst header files in my Java wrapper project: https://github.com/Nashatyrev/jc-kzg