### PR TITLE
Add KZG_CFLAGS env var to compiler options for passing additional compiler options

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -10,24 +10,24 @@ INCLUDE_DIRS = ../inc
 .PRECIOUS: %.o
 
 %.o: %.c %.h c_kzg.h Makefile
-	clang -Wall -I$(INCLUDE_DIRS) $(CFLAGS) -c $*.c
+	clang -Wall -I$(INCLUDE_DIRS) $(CFLAGS) $(KZG_CFLAGS) -c $*.c
 
 libckzg.a: $(LIB_OBJ) Makefile
 	ar rc libckzg.a $(LIB_OBJ)
 
 %_test: %_test.c debug_util.o test_util.o libckzg.a Makefile
-	clang -Wall -I$(INCLUDE_DIRS) $(CFLAGS) -o $@ $@.c debug_util.o test_util.o libckzg.a -L../lib -lblst
+	clang -Wall -I$(INCLUDE_DIRS) $(CFLAGS) $(KZG_CFLAGS) -o $@ $@.c debug_util.o test_util.o libckzg.a -L../lib -lblst
 	./$@
 
 # This version will abort on error and print the file and line number
 %_test_debug: CFLAGS += -g -O0 -DDEBUG
 %_test_debug: %_test.c debug_util.o test_util.o libckzg.a Makefile
-	clang -Wall -I$(INCLUDE_DIRS) $(CFLAGS) -o $@ $*_test.c debug_util.o test_util.o libckzg.a -L../lib -lblst
+	clang -Wall -I$(INCLUDE_DIRS) $(CFLAGS) $(KZG_CFLAGS) -o $@ $*_test.c debug_util.o test_util.o libckzg.a -L../lib -lblst
 
 # Benchmarks
 %_bench: CFLAGS += -O
 %_bench: %_bench.c bench_util.o test_util.o $(LIB_OBJ) Makefile
-	clang -Wall -I$(INCLUDE_DIRS) $(CFLAGS) -o $@ $@.c bench_util.o test_util.o $(LIB_OBJ) -L../lib -lblst
+	clang -Wall -I$(INCLUDE_DIRS) $(CFLAGS) $(KZG_CFLAGS) -o $@ $@.c bench_util.o test_util.o $(LIB_OBJ) -L../lib -lblst
 	./$@
 
 lib: CFLAGS += -O

--- a/src/Makefile
+++ b/src/Makefile
@@ -4,7 +4,7 @@ BENCH = fft_fr_bench fft_g1_bench recover_bench zero_poly_bench
 LIB_SRC = bls12_381.c c_kzg_util.c das_extension.c fft_common.c fft_fr.c fft_g1.c fk20_proofs.c kzg_proofs.c poly.c recover.c utility.c zero_poly.c
 LIB_OBJ = $(LIB_SRC:.c=.o)
 
-CFLAGS =
+KZG_CFLAGS =
 INCLUDE_DIRS = ../inc
 
 .PRECIOUS: %.o
@@ -20,20 +20,20 @@ libckzg.a: $(LIB_OBJ) Makefile
 	./$@
 
 # This version will abort on error and print the file and line number
-%_test_debug: CFLAGS += -g -O0 -DDEBUG
+%_test_debug: KZG_CFLAGS += -g -O0 -DDEBUG
 %_test_debug: %_test.c debug_util.o test_util.o libckzg.a Makefile
 	clang -Wall -I$(INCLUDE_DIRS) $(CFLAGS) $(KZG_CFLAGS) -o $@ $*_test.c debug_util.o test_util.o libckzg.a -L../lib -lblst
 
 # Benchmarks
-%_bench: CFLAGS += -O
+%_bench: KZG_CFLAGS += -O
 %_bench: %_bench.c bench_util.o test_util.o $(LIB_OBJ) Makefile
 	clang -Wall -I$(INCLUDE_DIRS) $(CFLAGS) $(KZG_CFLAGS) -o $@ $@.c bench_util.o test_util.o $(LIB_OBJ) -L../lib -lblst
 	./$@
 
-lib: CFLAGS += -O
+lib: KZG_CFLAGS += -O
 lib: clean libckzg.a
 
-profilelib: CFLAGS += -fprofile-instr-generate -fcoverage-mapping
+profilelib: KZG_CFLAGS += -fprofile-instr-generate -fcoverage-mapping
 profilelib: clean libckzg.a
 
 test: $(TESTS)


### PR DESCRIPTION
On Linux I'm now using the project `Makefile` to build C-KZG `.a` library first and then link it to `libjc-kzg.so`. 
I need to pass some compiler options from outside (`-fPIC` and additional `-I`)

This PR adds `$(KZG_CFLAGS)` to all `clang` commands