### PR TITLE
Add fr_to_uint64s() function

### DIFF
--- a/src/bls12_381.c
+++ b/src/bls12_381.c
@@ -122,6 +122,16 @@ void fr_from_uint64(fr_t *out, uint64_t n) {
 }
 
 /**
+ * Convert the field element to an array of four 64-bit unsigned integers.
+ *
+ * @param out  array for returned values, little-endian ordering of the 64-bit words
+ * @param vals The field element equivalent of @p n
+ */
+void fr_to_uint64s(uint64_t out[4], const fr_t* fr) {
+    blst_uint64_from_fr(out, fr);
+}
+
+/**
  * Test whether two field elements are equal.
  *
  * @param[in] aa The first element

--- a/src/bls12_381.h
+++ b/src/bls12_381.h
@@ -104,6 +104,7 @@ bool fr_is_null(const fr_t *p);
 void fr_from_scalar(fr_t *out, const scalar_t *a);
 void fr_from_uint64s(fr_t *out, const uint64_t *vals);
 void fr_from_uint64(fr_t *out, uint64_t n);
+void fr_to_uint64s(uint64_t out[4], const fr_t* fr);
 bool fr_equal(const fr_t *aa, const fr_t *bb);
 void fr_negate(fr_t *out, const fr_t *in);
 void fr_add(fr_t *out, const fr_t *a, const fr_t *b);


### PR DESCRIPTION
I've annotated the param as `uint64_t[4]` instead of `uint64_t*` (as all others). Looks more informative to me though doesn't seem to affect type check in any way. 
I'm not a big C expert and not sure if it's the right style, so please ping me if the latter type is preferable