### PR TITLE
Fix toeplitz_coeffs_stride() for minimal sized poly

### DIFF
--- a/src/fk20_proofs.c
+++ b/src/fk20_proofs.c
@@ -623,7 +623,7 @@ void fk_multi_settings(void) {
     free_fk20_multi_settings(&fk);
 }
 
-void fk_multi_0_case(int chunk_len, int n) {
+void fk_multi_case(int chunk_len, int n) {
     FFTSettings fs;
     KZGSettings ks;
     FK20MultiSettings fk;
@@ -740,15 +740,15 @@ void fk_multi_0_case(int chunk_len, int n) {
 }
 
 void fk_multi_chunk_len_16_512() {
-    fk_multi_0_case(16, 512);
+    fk_multi_case(16, 512);
 }
 
 void fk_multi_chunk_len_1_512() {
-    fk_multi_0_case(1, 512);
+    fk_multi_case(1, 512);
 }
 
 void fk_multi_chunk_len_16_16() {
-    fk_multi_0_case(16, 16);
+    fk_multi_case(16, 16);
 }
 
 // TODO: compare results of fk20_multi_da_opt() and  fk20_compute_proof_multi()

--- a/src/fk20_proofs.c
+++ b/src/fk20_proofs.c
@@ -637,7 +637,6 @@ void fk_multi_0_case(int chunk_len) {
     fr_t *ys, *ys2;
     uint64_t domain_stride;
 
-    chunk_len = 16;
     chunk_count = 32;
     n = chunk_len * chunk_count;
     width = 4 + 5 + 1;

--- a/src/fk20_proofs.c
+++ b/src/fk20_proofs.c
@@ -130,7 +130,7 @@ static C_KZG_RET toeplitz_coeffs_stride(poly *out, const poly *in, uint64_t offs
     k2 = k * 2;
 
     out->coeffs[0] = in->coeffs[n - 1 - offset];
-    for (uint64_t i = 1; i <= k + 1; i++) {
+    for (uint64_t i = 1; i <= k + 1 & i < k2; i++) {
         out->coeffs[i] = fr_zero;
     }
     for (uint64_t i = k + 2, j = 2 * stride - offset - 1; i < k2; i++, j += stride) {

--- a/src/fk20_proofs.c
+++ b/src/fk20_proofs.c
@@ -621,11 +621,6 @@ void fk_multi_settings(void) {
     free_fk20_multi_settings(&fk);
 }
 
-void fk_multi_0() {
-    fk_multi_0_case(16);
-    fk_multi_0_case(1);
-}
-
 void fk_multi_0_case(int chunk_len) {
     FFTSettings fs;
     KZGSettings ks;
@@ -734,6 +729,11 @@ void fk_multi_0_case(int chunk_len) {
     free_fft_settings(&fs);
     free_kzg_settings(&ks);
     free_fk20_multi_settings(&fk);
+}
+
+void fk_multi_0() {
+    fk_multi_0_case(16);
+    fk_multi_0_case(1);
 }
 
 // TODO: compare results of fk20_multi_da_opt() and  fk20_compute_proof_multi()

--- a/src/fk20_proofs.c
+++ b/src/fk20_proofs.c
@@ -130,7 +130,7 @@ static C_KZG_RET toeplitz_coeffs_stride(poly *out, const poly *in, uint64_t offs
     k2 = k * 2;
 
     out->coeffs[0] = in->coeffs[n - 1 - offset];
-    for (uint64_t i = 1; i <= k + 1 & i < k2; i++) {
+    for (uint64_t i = 1; i <= k + 1 && i < k2; i++) {
         out->coeffs[i] = fr_zero;
     }
     for (uint64_t i = k + 2, j = 2 * stride - offset - 1; i < k2; i++, j += stride) {
@@ -621,11 +621,16 @@ void fk_multi_settings(void) {
     free_fk20_multi_settings(&fk);
 }
 
-void fk_multi_0(void) {
+void fk_multi_0() {
+    fk_multi_0_case(16);
+    fk_multi_0_case(1);
+}
+
+void fk_multi_0_case(int chunk_len) {
     FFTSettings fs;
     KZGSettings ks;
     FK20MultiSettings fk;
-    uint64_t n, chunk_len, chunk_count;
+    uint64_t n, chunk_count, width;
     uint64_t secrets_len;
     g1_t *s1;
     g2_t *s2;
@@ -640,13 +645,14 @@ void fk_multi_0(void) {
     chunk_len = 16;
     chunk_count = 32;
     n = chunk_len * chunk_count;
-    secrets_len = 2 * n;
+    width = 4 + 5 + 1;
+    secrets_len = 1 << width;
 
     TEST_CHECK(C_KZG_OK == new_g1_array(&s1, secrets_len));
     TEST_CHECK(C_KZG_OK == new_g2_array(&s2, secrets_len));
 
     generate_trusted_setup(s1, s2, &secret, secrets_len);
-    TEST_CHECK(C_KZG_OK == new_fft_settings(&fs, 4 + 5 + 1));
+    TEST_CHECK(C_KZG_OK == new_fft_settings(&fs, width));
     TEST_CHECK(C_KZG_OK == new_kzg_settings(&ks, s1, s2, secrets_len, &fs));
     TEST_CHECK(C_KZG_OK == new_fk20_multi_settings(&fk, n * 2, chunk_len, &ks));
 


### PR DESCRIPTION
When using `da_using_fk20_multi()` with (unextended) data size == sample size, the function `toeplitz_coeffs_stride()` writes `0` outside of `out` polynomial coeff array in the first loop. 
With the suggested additional condition works as expected